### PR TITLE
Change dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }
   ],
   "require": {
-    "symfony/yaml": "v3.2.6",
-    "symfony/config": "^3.3",
+    "symfony/yaml": ">=2.6.0",
+    "symfony/config": ">=2.6",
     "league/flysystem": "^1.0",
     "league/flysystem-aws-s3-v3": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "symfony/yaml": ">=2.6 <=3.0",
-    "symfony/config": ">=2.6.0",
+    "symfony/config": "^2.6.0",
     "league/flysystem": "^1.0",
     "league/flysystem-aws-s3-v3": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }
   ],
   "require": {
-    "symfony/yaml": ">=2.6.0",
-    "symfony/config": ">=2.6",
+    "symfony/yaml": ">=2.6 <=3.0",
+    "symfony/config": ">=2.6.0",
     "league/flysystem": "^1.0",
     "league/flysystem-aws-s3-v3": "^1.0"
   },


### PR DESCRIPTION
As we want to revert old integration tests in OMS we need to install DBUnit wich now is separate package from phpunit.
Installing DBUnit requires mathing dependencies.