### PR TITLE
[WMS-5393] Fix security vulnerability CVE-2021-32708

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Westwing-Home-and-Living/flysystem-factory",
+  "name": "westwing-home-and-living/flysystem-factory",
   "description": "Simple Factory for the League\\Flysystem filesystem abstraction library",
   "license": "MIT",
   "keywords": [ "flysystem", "filesystem", "filesystems", "abstraction", "factory" ],
@@ -12,7 +12,7 @@
   "require": {
     "symfony/yaml": ">=2.6 <=3.0",
     "symfony/config": "^2.6.0",
-    "league/flysystem": "^1.0",
+    "league/flysystem": "^1.1.4",
     "league/flysystem-aws-s3-v3": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Fix security vulnerability CVE-2021-32708 by upgrading flysystem version to 1.1.4;
fix uppercase package naming which is not accepted anymore by composer